### PR TITLE
S3を作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+resource/.terraform
+resource/terraform.tfstate*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://zenn.dev/take_tech/articles/32188cd3607721
 
 
 ## 使い方
-- AWS CLIのプロファイルを指定
+- AWS CLIのプロファイルをTerraform操作用のIAMユーザー(gourmet-liff-app-terraform)に指定
 ```bash
 export AWS_PROFILE=プロファイル名
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # liff-terraform
 LIFF Terraform
+
+## バージョン
+- Terraform v1.8.4
+- hashicorp/aws 5.61.0
+
+## Terraformのインストール
+- [公式サイト](https://developer.hashicorp.com/terraform/install)に従ってインストール
+```bash
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+```
+
+- インストールできたか確認
+```bash
+terraform version
+```
+```
+Terraform v1.9.5
+on darwin_arm64
+```
+### 参考
+https://zenn.dev/take_tech/articles/32188cd3607721
+
+
+## 使い方
+- AWS CLIのプロファイルを指定
+```bash
+export AWS_PROFILE=プロファイル名
+```
+プロファイルは登録済みであることが前提。https://zenn.dev/aiiro/articles/3ebaaf1ddc1312
+
+- 初回は以下のコマンドを実行
+```bash
+cd resource
+```
+```bash
+terraform init
+```
+初回は実行必須。
+.tf ファイルで利用している plugin（先述の例でいうと aws provider など）のダウンロード処理などが走る。
+
+- コードを変更したら以下のコマンドを実行
+```bash
+terraform plan
+```
+変更した内容によってどのようなリソースが 作成/修正/削除 されるかが出力される。
+意図した変更になっているか確認。
+
+- 以下のコマンドを実行しリソースを作成
+```bash
+terraform apply
+```
+変更内容をもとに実際にリソースが作成される。
+terraform.stateで状態管理しており、差分の内容だけが反映されるようになっている。
+
+## ディレクトリ設計
+- リソース種類ごとに1ファイル
+  - 例えばS3の定義は全てs3.tfに記述している。
+  - モジュール化すれば保守性は良くなりそうだが、リソースの数も限られているので現状はこの設計で問題ないかと思われる。

--- a/resource/config.tf
+++ b/resource/config.tf
@@ -1,0 +1,18 @@
+terraform {
+  # terraformの必要バージョンの指定
+  required_version = ">= 1.9.5"
+
+  # providerの必要バージョンの指定
+  # providerとは、terraformが操作できるクラウド(AWS,GCなど)のインターフェース
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.61.0"
+    }
+  }
+}
+
+provider "aws" {
+  # providerで利用するリージョンを指定
+  region  = "ap-northeast-1"
+}

--- a/resource/s3.tf
+++ b/resource/s3.tf
@@ -1,0 +1,43 @@
+# プライベートバケット
+
+# バックエンドのソースを保存する
+# NOTE: バケットポリシーではなくLambdaやIAMユーザーなどアクセスする側に権限付与する設計
+resource "aws_s3_bucket" "private-backend" {
+  bucket = "gourmet-liff-app-backend-source-bucket"
+}
+resource "aws_s3_bucket_public_access_block" "private-backend" {
+  bucket = aws_s3_bucket.private-backend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# NOTE: OAIを設定して、バケットポリシーでOAIからのアクセスのみを許可するように制御する設計
+# TODO: CloudFront、OAC、OACからのアクセスを許可するバケットポリシーするの作成が必要(OACはバケットポリシーじゃないと制御できない)
+# フロントエンドのソースを保存するバケット
+resource "aws_s3_bucket" "private-frontend" {
+  bucket = "gourmet-liff-app-frontend-source-bucket"
+}
+resource "aws_s3_bucket_public_access_block" "private-frontend" {
+  bucket = aws_s3_bucket.private-frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# 画像を保存するバケット
+resource "aws_s3_bucket" "private-photo" {
+  bucket = "gourmet-liff-app-photo-bucket"
+}
+resource "aws_s3_bucket_public_access_block" "private-photo" {
+  bucket = aws_s3_bucket.private-photo.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
## 対応
以下に作成したバケットの用途と実際に使うにあたっての残課題をまとめました。
AWS環境にapply済みです。
全てプライベートバケットです。

- バックエンドのソースを保存するバケット
    - 用途
        - SAMのデプロイでLambdaのソースを保存する
    - 残課題
        - Lambdaへのロール付与。(LambdaがS3のソースを参照するので多分必要)
        - IAMユーザーはliff-app-groupというユーザーグループに追加されていればアクセスできるはず。
- フロントエンドのソースを保存するバケット
    - 用途
        - ユーザーがアクセスする画面
    - 残課題
        - CloudFront
        - OAC
        - OACからのアクセスを許可するバケットポリシー(ロールでの制御はできないぽい)
- 画像を保存するバケット
    - 用途
        - 飲食店やご飯の写真を保存する
    - 残課題
        - CloudFront
        - OAC
        - OACからのアクセスを許可するバケットポリシー(ロールでの制御はできないぽい)
 
## 備考
- CloudFront作成は別チケットにて対応する
- ユーザーがアクセスするコンテンツは、Cloud Front→S3のアクセスに限定したいので、OACを作成しOACのみがS3にアクセスできるような設計で考えています
- OACの作成についてメモ
    - https://aws.amazon.com/jp/blogs/news/amazon-cloudfront-introduces-origin-access-control-oac/
    - https://qiita.com/shota_hagiwara/items/caacbda7f55aeea110d1
    - https://zenn.dev/kou_pg_0131/articles/tf-cloudfront-oac